### PR TITLE
➕  Add `gcc`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ apt-get install --yes --no-install-recommends \
   "git=1:2.43.0-1ubuntu7" \
   "jq=1.7.1-3build1" \
   "libicu-dev=74.2-1ubuntu3" \
-  "lsb-release=12.0-2"
+  "lsb-release=12.0-2" \
+  "gcc=4:13.2.0-7ubuntu1"
 
 apt-get clean
 


### PR DESCRIPTION
Rather self explanatory. Required by an action in the `airflow` repository.