### PR TITLE
:octocat: Actions Runner 2.320.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ENV CONTAINER_USER="runner" \
     CONTAINER_GID="10000" \
     CONTAINER_HOME="/actions-runner" \
     DEBIAN_FRONTEND="noninteractive" \
-    ACTIONS_RUNNER_VERSION="2.319.1" \
-    ACTIONS_RUNNER_PKG_SHA="3f6efb7488a183e291fc2c62876e14c9ee732864173734facc85a1bfb1744464"
+    ACTIONS_RUNNER_VERSION="2.320.0" \
+    ACTIONS_RUNNER_PKG_SHA="93ac1b7ce743ee85b5d386f5c1787385ef07b3d7c728ff66ce0d3813d5f46900"
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: actions-runner
 description: Deploy GitHub Actions self-hosted runner
 type: application
-version: 2.319.1-3
-appVersion: 2.319.1-3
+version: 2.320.0-1
+appVersion: 2.320.0-1
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Ministry_of_Justice_logo_%28United_Kingdom%29.svg/611px-Ministry_of_Justice_logo_%28United_Kingdom%29.svg.png
 maintainers:
   - name: moj-data-platform-robot

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   pullPolicy: IfNotPresent
   repository: ghcr.io/ministryofjustice/analytical-platform-actions-runner
-  tag: 2.319.1-3
+  tag: 2.320.0-1
 
 imagePullSecrets: []
 

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -26,6 +26,11 @@ commandTests:
     args: ["--groups", "runner"]
     expectedOutput: ["100"]
 
+  - name: "actions-runner"
+    command: "bash"
+    args: ["run.sh", "--version"]
+    expectedOutput: ["2.320.0"]
+
 fileExistenceTests:
   - name: "/usr/local/bin/entrypoint.sh"
     path: "/usr/local/bin/entrypoint.sh"


### PR DESCRIPTION
This pull request:

- Relates to https://github.com/ministryofjustice/data-platform-support/issues/864
- Updates Actions Runner to [2.320.0](https://github.com/actions/runner/releases/tag/v2.320.0)
- Adds a test for Actions Runner version
- Prepares `2.320.0-1` release

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 