### PR TITLE
:octocat: GitHub App for KEDA authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #checkov:skip=CKV_DOCKER_2:actions/runner does not provider a mechanism for checking the health of the service
-FROM public.ecr.aws/ubuntu/ubuntu@sha256:5b2fc4131b3c134a019c3ea815811de70e6ad9ee1626f59bf302558a95b436e5
+FROM public.ecr.aws/ubuntu/ubuntu@sha256:fb95efe0d22be277f10250f15e5172ec0fe22c37eca2ba55e78b526c447eec23
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: actions-runner
 description: Deploy GitHub Actions self-hosted runner
 type: application
-version: 2.320.0-4-rc1
-appVersion: 2.320.0-4-rc1
+version: 2.320.0-4
+appVersion: 2.320.0-4
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Ministry_of_Justice_logo_%28United_Kingdom%29.svg/611px-Ministry_of_Justice_logo_%28United_Kingdom%29.svg.png
 maintainers:
   - name: moj-data-platform-robot

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: actions-runner
 description: Deploy GitHub Actions self-hosted runner
 type: application
-version: 2.320.0-3
-appVersion: 2.320.0-3
+version: 2.320.0-4-rc1
+appVersion: 2.320.0-4-rc1
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Ministry_of_Justice_logo_%28United_Kingdom%29.svg/611px-Ministry_of_Justice_logo_%28United_Kingdom%29.svg.png
 maintainers:
   - name: moj-data-platform-robot

--- a/chart/templates/scaled-job.yaml
+++ b/chart/templates/scaled-job.yaml
@@ -77,8 +77,8 @@ spec:
         repos: {{ .Values.github.repository }}
         labels: {{ .Values.github.runner.labels | quote }}
         runnerScope: "repo"
-        applicationID: {{ .Values.github.app.applicationID }}
-        installationID: {{ .Values.github.app.installationID }}
+        applicationID: {{ .Values.github.app.applicationID | quote }}
+        installationID: {{ .Values.github.app.installationID | quote }}
       authenticationRef:
         name: {{ .Release.Name }}-github-trigger-auth
 {{- end }}

--- a/chart/templates/scaled-job.yaml
+++ b/chart/templates/scaled-job.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   secretTargetRef:
     - parameter: appKey
-      name: {{ .Values.keda.triggerAuthentication.secretTargetRef.name }}
-      key: {{ .Values.keda.triggerAuthentication.secretTargetRef.key }}
+      name: {{ .Values.ephemeral.keda.triggerAuthentication.secretTargetRef.name }}
+      key: {{ .Values.ephemeral.keda.triggerAuthentication.secretTargetRef.key }}
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob

--- a/chart/templates/scaled-job.yaml
+++ b/chart/templates/scaled-job.yaml
@@ -6,9 +6,9 @@ metadata:
   name: {{ .Release.Name }}-github-trigger-auth
 spec:
   secretTargetRef:
-    - parameter: personalAccessToken
-      name: {{ .Values.github.tokenSecretName }}
-      key: {{ .Values.github.tokenSecretKey }}
+    - parameter: appKey
+      name: {{ .Values.keda.triggerAuthentication.secretTargetRef.name }}
+      key: {{ .Values.keda.triggerAuthentication.secretTargetRef.key }}
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
@@ -77,6 +77,8 @@ spec:
         repos: {{ .Values.github.repository }}
         labels: {{ .Values.github.runner.labels | quote }}
         runnerScope: "repo"
+        applicationID: {{ .Values.github.app.applicationID }}
+        installationID: {{ .Values.github.app.installationID }}
       authenticationRef:
         name: {{ .Release.Name }}-github-trigger-auth
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   pullPolicy: IfNotPresent
   repository: ghcr.io/ministryofjustice/analytical-platform-actions-runner
-  tag: 2.320.0-3
+  tag: 2.320.0-4-rc1
 
 imagePullSecrets: []
 
@@ -40,6 +40,9 @@ github:
   tokenSecretKey: token
   runner:
     labels:
+  app:
+    applicationID:
+    installationID:
 
 ephemeral:
   enabled: true
@@ -47,5 +50,9 @@ ephemeral:
     enabled: true
     nodePool: "general-spot"
   keda:
-    maxReplicaCount: 15
+    triggerAuthentication:
+      secretTargetRef:
+        name: actions-runners-github-app-apc-self-hosted-runners
+        key: private-key
+    maxReplicaCount: 20
     pollingInterval: 20

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   pullPolicy: IfNotPresent
   repository: ghcr.io/ministryofjustice/analytical-platform-actions-runner
-  tag: 2.320.0-4-rc1
+  tag: 2.320.0-4
 
 imagePullSecrets: []
 


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5962
- Switches KEDA to GitHub App authentication

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 