### PR TITLE
👻 Add hostAliases

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: actions-runner
 description: Deploy GitHub Actions self-hosted runner
 type: application
-version: 2.323.0-2
-appVersion: 2.323.0-2
+version: 2.323.0-3
+appVersion: 2.323.0-3
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Ministry_of_Justice_logo_%28United_Kingdom%29.svg/611px-Ministry_of_Justice_logo_%28United_Kingdom%29.svg.png
 maintainers:
   - name: moj-data-platform-robot

--- a/chart/ci/lint-values.yaml
+++ b/chart/ci/lint-values.yaml
@@ -10,3 +10,13 @@ github:
 serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/this-is-not-a-real-role
+
+hostAliases:
+  - ip: "127.0.0.1"
+    hostnames:
+      - "foo.local"
+      - "bar.local"
+  - ip: "127.0.0.2"
+    hostnames:
+      - "baz.local"
+      - "qux.local"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -46,4 +46,6 @@ spec:
               value: {{ .Values.github.runner.labels | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          hostAliases:
+            {{- toYaml .Values.hostAliases | nindent 12 }}
 {{- end }}

--- a/chart/templates/scaled-job.yaml
+++ b/chart/templates/scaled-job.yaml
@@ -37,6 +37,8 @@ spec:
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             resources:
               {{- toYaml .Values.resources | nindent 14 }}
+            hostAliases:
+              {{- toYaml .Values.hostAliases | nindent 14 }}
             env:
               - name: EPHEMERAL
                 value: "true"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   pullPolicy: IfNotPresent
   repository: ghcr.io/ministryofjustice/analytical-platform-actions-runner
-  tag: 2.323.0-2
+  tag: 2.323.0-3
 
 imagePullSecrets: []
 


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/analytical-platform/issues/7630

## Proposed Changes

- Adds `hostAliases`

CI values render to 

```yaml
...
      spec:
        serviceAccountName: release-name-actions-runner
        containers:
          - name: actions-runner
            image: "ghcr.io/ministryofjustice/analytical-platform-actions-runner:2.323.0-3"
            imagePullPolicy: IfNotPresent
            resources:
              limits:
                cpu: 2
                memory: 7Gi
              requests:
                cpu: 1
                memory: 5Gi
            hostAliases:
              - hostnames:
                - foo.local
                - bar.local
                ip: 127.0.0.1
              - hostnames:
                - baz.local
                - qux.local
                ip: 127.0.0.2
```

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>