### PR TITLE
🚑 Fix hostAliases

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: actions-runner
 description: Deploy GitHub Actions self-hosted runner
 type: application
-version: 2.323.0-5
-appVersion: 2.323.0-5
+version: 2.323.0-6
+appVersion: 2.323.0-6
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Ministry_of_Justice_logo_%28United_Kingdom%29.svg/611px-Ministry_of_Justice_logo_%28United_Kingdom%29.svg.png
 maintainers:
   - name: moj-data-platform-robot

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -46,6 +46,6 @@ spec:
               value: {{ .Values.github.runner.labels | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          hostAliases:
-            {{- toYaml .Values.hostAliases | nindent 12 }}
+      hostAliases:
+        {{- toYaml .Values.hostAliases | nindent 8 }}
 {{- end }}

--- a/chart/templates/scaled-job.yaml
+++ b/chart/templates/scaled-job.yaml
@@ -37,8 +37,7 @@ spec:
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             resources:
               {{- toYaml .Values.resources | nindent 14 }}
-            hostAliases:
-              {{- toYaml .Values.hostAliases | nindent 14 }}
+
             env:
               - name: EPHEMERAL
                 value: "true"
@@ -51,6 +50,8 @@ spec:
                   secretKeyRef:
                     name: {{ .Values.github.tokenSecretName }}
                     key: {{ .Values.github.tokenSecretKey }}
+        hostAliases:
+          {{- toYaml .Values.hostAliases | nindent 10 }}
         {{- if .Values.ephemeral.karpenter.enabled }}
         restartPolicy: Never
         affinity:

--- a/chart/templates/scaled-job.yaml
+++ b/chart/templates/scaled-job.yaml
@@ -25,7 +25,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
         labels:
-          {{- include "actions-runner.labels" . | nindent 8 }}
+          {{- include "actions-runner.labels" . | nindent 10 }}
     {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}
           {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   pullPolicy: IfNotPresent
   repository: ghcr.io/ministryofjustice/analytical-platform-actions-runner
-  tag: 2.323.0-5
+  tag: 2.323.0-6
 
 imagePullSecrets: []
 


### PR DESCRIPTION
## Proposed Changes

- Moves `hostAliases` up to `spec.hostAliases`

```yaml
spec:
  jobTargetRef:
    template:
      metadata:
        labels:
          ...
      spec:
        serviceAccountName: cadet-actions-runner
        containers:
          - name: actions-runner
            image: "ghcr.io/ministryofjustice/analytical-platform-actions-runner:2.323.0-5"
            ...
            env:
              ...
        hostAliases:
          - hostnames:
            - foo.local
            - bar.local
            ip: 127.0.0.1
          - hostnames:
            - baz.local
            - qux.local
            ip: 127.0.0.2
```

Source: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>