### PR TITLE
chore: bump ministryofjustice/analytical-platform-github-actions to v6.5.0

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -13,4 +13,4 @@ jobs:
     name: Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@9e604949e842733e0990f5eb6627844e8715deeb # v6.4.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@12a73dc031fe7e355f2691a38bdfd190dc6983de # v6.5.0

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -13,6 +13,6 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@9e604949e842733e0990f5eb6627844e8715deeb # v6.4.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@12a73dc031fe7e355f2691a38bdfd190dc6983de # v6.5.0
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Updates ministryofjustice/analytical-platform-github-actions/ to pinned commit 12a73dc031fe7e355f2691a38bdfd190dc6983de (v6.5.0).