### PR TITLE
Patch GitHub Actions self-hosted runner 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Health checks are implemented downstream of this image
 
-FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:748740465d0aadaa69ab6e6c295892f17d7a8f44a85090dbb571ec0bb8c5674f
+FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:22a8228e1e48cbe7e0e0f2056e752ffb8a35950cda150a4e5e16417200bec648
 
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
@@ -15,8 +15,8 @@ ENV CONTAINER_USER="runner" \
     CONTAINER_GID="10000" \
     CONTAINER_HOME="/actions-runner" \
     DEBIAN_FRONTEND="noninteractive" \
-    ACTIONS_RUNNER_VERSION="2.333.1" \
-    ACTIONS_RUNNER_PKG_SHA="18f8f68ed1892854ff2ab1bab4fcaa2f5abeedc98093b6cb13638991725cab74" \
+    ACTIONS_RUNNER_VERSION="2.335.1" \
+    ACTIONS_RUNNER_PKG_SHA="4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf" \
     MICROSOFT_SQL_ODBC_VERSION="18.6.2.1-1" \
     MICROSOFT_SQL_TOOLS_VERSION="18.6.2.1-1" \
     PATH="/opt/mssql-tools18/bin:${PATH}"
@@ -43,13 +43,13 @@ apt-get update
 
 apt-get install --yes --no-install-recommends \
   "apt-transport-https=2.8.3" \
-  "ca-certificates=20240203" \
-  "curl=8.5.0-2ubuntu10.8" \
+  "ca-certificates=20260601~24.04.1" \
+  "curl=8.5.0-2ubuntu10.9" \
   "gettext=0.21-14ubuntu2" \
   "git=1:2.43.0-1ubuntu7.3" \
   "gcc=4:13.2.0-7ubuntu1" \
   "gpg=2.4.4-2ubuntu17.4" \
-  "jq=1.7.1-3ubuntu0.24.04.1" \
+  "jq=1.7.1-3ubuntu0.24.04.2" \
   "libicu-dev=74.2-1ubuntu3.1" \
   "libsqlite3-dev=3.45.1-1ubuntu2.5" \
   "lsb-release=12.0-2"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: actions-runner
 description: Deploy GitHub Actions self-hosted runner
 type: application
-version: 2.330.0-7
-appVersion: 2.330.0-7
+version: 2.330.0-8
+appVersion: 2.330.0-8
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Ministry_of_Justice_logo_%28United_Kingdom%29.svg/611px-Ministry_of_Justice_logo_%28United_Kingdom%29.svg.png
 maintainers:
   - name: moj-data-platform-robot

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   pullPolicy: IfNotPresent
   repository: ghcr.io/ministryofjustice/analytical-platform-actions-runner
-  tag: 2.330.0-7
+  tag: 2.330.0-8
 
 imagePullSecrets: []
 

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -29,7 +29,7 @@ commandTests:
   - name: "actions-runner"
     command: "bash"
     args: ["run.sh", "--version"]
-    expectedOutput: ["2.333.1"]
+    expectedOutput: ["2.335.1"]
 
   - name: "sqlcmd"
     command: "sqlcmd"


### PR DESCRIPTION
This pull request updates the GitHub Actions self-hosted runner to use the latest upstream versions and patches, including a new base Ubuntu image, updated runner version, and refreshed package dependencies. It also bumps the chart and image tags to reflect these updates.

**Base image and dependency updates:**
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R3): Updated the base Ubuntu image to a newer digest for improved security and upstream patches.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L46-R52): Refreshed several package versions (`ca-certificates`, `curl`, `jq`) to their latest patch releases for enhanced security and stability.

**Actions runner version update:**
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L18-R19): Upgraded `ACTIONS_RUNNER_VERSION` from `2.333.1` to `2.335.1` and updated the corresponding package SHA.
* [`test/container-structure-test.yml`](diffhunk://#diff-44a6e41556139409675f12dd3f067ac9c96930647809395f52f7a9eef8b9a2b5L32-R32): Updated the expected output in the `actions-runner` command test to match the new runner version.

**Chart and image version bump:**
* `chart/Chart.yaml`, `chart/values.yaml`: Bumped chart and image tags from `2.330.0-7` to `2.330.0-8` to reflect the new release. [[1]](diffhunk://#diff-462f538e090c491e7d916fd38843be03a198e0ed4f9c266b5704ef7af3244948L6-R7) [[2]](diffhunk://#diff-a9d07052701ab3b718c82ac0fe74b965a8260b06bb5906362081718b0ee593b4L10-R10)