### PR TITLE
changed sched run and vuln fix

### DIFF
--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -3,7 +3,7 @@ name: ⏰ Scheduled Container Scan
 
 on:
   schedule:
-    - cron: "0 9 * * 1-5" # Every weekday at 9AM UTC
+    - cron: "0 7 * * 1-5" # Every weekday at 7AM UTC
   workflow_dispatch:
 
 permissions: {}
@@ -13,6 +13,6 @@ jobs:
     name: Scheduled Container Scan
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@9539f487ca3cb11b6dd1a45c41c6b78d4fe8c7b3 # v8.0.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-scheduled-container-scan.yml@aa8abd093cd24a89b8dd2d76b6733d8121c64c52 # v8.0.3
     secrets:
       cve-scan-slack-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_CVE_SCAN_SLACK_WEBHOOK_URL }}

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -50,3 +50,11 @@ ignore:
   # undici < 6.27.0
   - vulnerability: GHSA-vxpw-j846-p89q
     reason: "Bundled in Actions Runner externals/node24 - not user-installable"
+
+  # sigstore < 4.1.1
+  - vulnerability: GHSA-52v5-jr5w-gjxr
+    reason: "Bundled in Actions Runner externals/node20 - not user-installable"
+
+  # sigstore < 4.1.1
+  - vulnerability: GHSA-52v5-jr5w-gjxr
+    reason: "Bundled in Actions Runner externals/node24 - not user-installable"

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,15 @@ apt-get install --yes --no-install-recommends \
   "git=1:2.43.0-1ubuntu7.3" \
   "gcc=4:13.2.0-7ubuntu1" \
   "gpg=2.4.4-2ubuntu17.4" \
+  "gzip=1.12-1ubuntu3.2" \
   "jq=1.7.1-3ubuntu0.24.04.2" \
   "libicu-dev=74.2-1ubuntu3.1" \
   "libsqlite3-dev=3.45.1-1ubuntu2.6" \
-  "lsb-release=12.0-2"
+  "lsb-release=12.0-2" \
+  "libncursesw6=6.4+20240113-1ubuntu2.1" \
+  "libtinfo6=6.4+20240113-1ubuntu2.1" \
+  "ncurses-base=6.4+20240113-1ubuntu2.1" \
+  "ncurses-bin=6.4+20240113-1ubuntu2.1"
 
 apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,14 +44,14 @@ apt-get update
 apt-get install --yes --no-install-recommends \
   "apt-transport-https=2.8.3" \
   "ca-certificates=20260601~24.04.1" \
-  "curl=8.5.0-2ubuntu10.9" \
+  "curl=8.5.0-2ubuntu10.11" \
   "gettext=0.21-14ubuntu2" \
   "git=1:2.43.0-1ubuntu7.3" \
   "gcc=4:13.2.0-7ubuntu1" \
   "gpg=2.4.4-2ubuntu17.4" \
   "jq=1.7.1-3ubuntu0.24.04.2" \
   "libicu-dev=74.2-1ubuntu3.1" \
-  "libsqlite3-dev=3.45.1-1ubuntu2.5" \
+  "libsqlite3-dev=3.45.1-1ubuntu2.6" \
   "lsb-release=12.0-2"
 
 apt-get clean


### PR DESCRIPTION
Changed the schedule to run at `7 AM UTC` instead of `9 AM`, because we're using a shared runner, which doesn't guarantee the exact scheduled run time. This way, by the time our office hours start, we should already have the scan results. Also changed the github actions run `reusable-scheduled-container-scan.yml` version.

- pinned these versions
```
  curl=8.5.0-2ubuntu10.11
  gzip=1.12-1ubuntu3.2
  libsqlite3-dev=3.45.1-1ubuntu2.6
  lsb-release=12.0-2
  libncursesw6=6.4+20240113-1ubuntu2.1
  libtinfo6=6.4+20240113-1ubuntu2.1
  ncurses-base=6.4+20240113-1ubuntu2.1
  ncurses-bin=6.4+20240113-1ubuntu2.1
```
- ignoring the known vuln for `GHSA-52v5-jr5w-gjxr`

PR is part of [this](https://github.com/ministryofjustice/data-platform/issues/529) ticket.