### PR TITLE
Update libsqlite3-dev pinned version

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -49,15 +49,15 @@ ignore:
 
   # tar <= 7.5.17
   - vulnerability: GHSA-8x88-c5mf-7j5w
-    reason: "Bundled in Actions Runner externals/node20 and externals/node24 - not user-installable"
+    reason: "Bundled in Actions Runner externals/node20 and externals/node24 - not user-installable. exp:2026-08-01"
 
   # tar <= 7.5.18
   - vulnerability: GHSA-23hp-3jrh-7fpw
-    reason: "Bundled in Actions Runner externals/node20 and externals/node24 - not user-installable"
+    reason: "Bundled in Actions Runner externals/node20 and externals/node24 - not user-installable. exp:2026-08-01"
 
   # brace-expansion >= 2.0.0, < 2.1.2 and >= 3.0.0, < 5.0.7
   - vulnerability: GHSA-3jxr-9vmj-r5cp
-    reason: "Bundled in Actions Runner externals/node20 and externals/node24 - not user-installable"
+    reason: "Bundled in Actions Runner externals/node20 and externals/node24 - not user-installable. exp:2026-08-01"
 
   # undici < 6.27.0
   - vulnerability: GHSA-vxpw-j846-p89q

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -47,6 +47,18 @@ ignore:
   - vulnerability: GHSA-9ppj-qmqm-q256
     reason: "Bundled in Actions Runner externals/node20 - not user-installable"
 
+  # tar <= 7.5.17
+  - vulnerability: GHSA-8x88-c5mf-7j5w
+    reason: "Bundled in Actions Runner externals/node20 and externals/node24 - not user-installable"
+
+  # tar <= 7.5.18
+  - vulnerability: GHSA-23hp-3jrh-7fpw
+    reason: "Bundled in Actions Runner externals/node20 and externals/node24 - not user-installable"
+
+  # brace-expansion >= 2.0.0, < 2.1.2 and >= 3.0.0, < 5.0.7
+  - vulnerability: GHSA-3jxr-9vmj-r5cp
+    reason: "Bundled in Actions Runner externals/node20 and externals/node24 - not user-installable"
+
   # undici < 6.27.0
   - vulnerability: GHSA-vxpw-j846-p89q
     reason: "Bundled in Actions Runner externals/node24 - not user-installable"

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ apt-get install --yes --no-install-recommends \
   "gzip=1.12-1ubuntu3.2" \
   "jq=1.7.1-3ubuntu0.24.04.2" \
   "libicu-dev=74.2-1ubuntu3.1" \
-  "libsqlite3-dev=3.45.1-1ubuntu2.6" \
+  "libsqlite3-dev=3.45.1-1ubuntu2.7" \
   "lsb-release=12.0-2" \
   "libncursesw6=6.4+20240113-1ubuntu2.1" \
   "libtinfo6=6.4+20240113-1ubuntu2.1" \


### PR DESCRIPTION
This pull request makes security and dependency updates to the project configuration files. The most important changes are:

Security vulnerability management:

* [`.grype.yaml`](diffhunk://#diff-d929405c8d1f27de6b8eaa31eab07468a9bc588d8466f23666f329595e8a70edR50-R61): Added ignores for three additional vulnerabilities (`GHSA-8x88-c5mf-7j5w`, `GHSA-23hp-3jrh-7fpw`, and `GHSA-3jxr-9vmj-r5cp`) affecting `tar` and `brace-expansion` packages, with justifications and expiration dates, since these are bundled in Actions Runner and are not user-installable.

Dependency updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L55-R55): Updated the `libsqlite3-dev` package version from `3.45.1-1ubuntu2.6` to `3.45.1-1ubuntu2.7` to ensure the latest patch is used.