### PR TITLE
added cve to ignore

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,14 +1,19 @@
 {
   "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:": {
+      "version": "2.14.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:445e84b0c213225bfdae977a72b4125f65e38eadcd49616dae04f1af24aa122d",
+      "integrity": "sha256:445e84b0c213225bfdae977a72b4125f65e38eadcd49616dae04f1af24aa122d"
+    },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "2.13.0",
       "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ac0a882e936ba6275d7f4ed5ebfc09e4ddca8cbcaeaad18b412beacddeb2fa91",
       "integrity": "sha256:ac0a882e936ba6275d7f4ed5ebfc09e4ddca8cbcaeaad18b412beacddeb2fa91"
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:": {
-      "version": "2.14.0",
-      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:445e84b0c213225bfdae977a72b4125f65e38eadcd49616dae04f1af24aa122d",
-      "integrity": "sha256:445e84b0c213225bfdae977a72b4125f65e38eadcd49616dae04f1af24aa122d"
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
     "ghcr.io/ministryofjustice/devcontainer-feature/container-structure-test:1": {
       "version": "1.0.0",

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -58,6 +58,8 @@ ignore:
   # brace-expansion >= 2.0.0, < 2.1.2 and >= 3.0.0, < 5.0.7
   - vulnerability: GHSA-3jxr-9vmj-r5cp
     reason: "Bundled in Actions Runner externals/node20 and externals/node24 - not user-installable. exp:2026-08-01"
+  - vulnerability: GHSA-mh99-v99m-4gvg
+    reason: "Bundled in Actions Runner externals/node20 and externals/node24 - not user-installable. exp:2026-08-01"
 
   # undici < 6.27.0
   - vulnerability: GHSA-vxpw-j846-p89q


### PR DESCRIPTION
This pull request makes updates to the development container and vulnerability ignore configuration. The main changes are the addition of a new feature to the devcontainer lock file and the inclusion of a new vulnerability exception in the Grype configuration.

Development container updates:

* Added the `github-cli` feature (version 1.1.0) to `.devcontainer/devcontainer-lock.json` to ensure the GitHub CLI is available in the development environment.

Security configuration:

* Added an ignore rule for vulnerability `GHSA-mh99-v99m-4gvg` in `.grype.yaml`, with a note that it is bundled in Actions Runner and not user-installable.